### PR TITLE
Use marionette-client which is compatible with m-c tip

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "yargs": "^1.3.2"
   },
   "peerDependencies": {
-    "marionette-client": "1.7.x"
+    "marionette-client": "1.8.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphene-marionette-runner",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "The Graphene Team"
   },


### PR DESCRIPTION
This changeset introduces incompatibilities with marionette-client.
1.8.x client works with the new marionette server.
